### PR TITLE
Provide relative_url to before_request

### DIFF
--- a/docs/nap-api.md
+++ b/docs/nap-api.md
@@ -133,6 +133,9 @@ This method can be overridden to customize each request.
 * `method`
     The HTTP method of request in upper case. For example `'GET'`.
 
+* `relative_url`
+    The relative URL passed to the HTTP method, without leading slash.
+
 * `request_kwargs`
     Keyword arguments that were passed to the request method.
     This does not contain the default keyword arguments given when

--- a/nap/url.py
+++ b/nap/url.py
@@ -66,12 +66,13 @@ class Url(object):
 
     # Overridable methods to extend behavior
 
-    def before_request(self, method, request_kwargs):
+    def before_request(self, method, relative_url, request_kwargs):
         """This method can be overridden to customize each request.
 
         * `method`
             The HTTP method of request in upper case. For example `'GET'`.
-
+        * `relative_url`
+            The relative URL passed to the HTTP method, without leading slash.
         * `request_kwargs`
             Keyword arguments that were passed to the request method.
             This does not contain the default keyword arguments given when
@@ -117,6 +118,7 @@ class Url(object):
         new_kwargs = self.default_kwargs().copy()
         custom_kwargs = self.before_request(
             http_method,
+            relative_url,
             kwargs.copy()
         )
         new_kwargs.update(custom_kwargs)

--- a/test/test_nap_extend_behavior.py
+++ b/test/test_nap_extend_behavior.py
@@ -14,7 +14,7 @@ from nap.url import Url
 
 class NewUrl(Url):
 
-    def before_request(self, method, request_kwargs):
+    def before_request(self, method, relative_url, request_kwargs):
         request_kwargs['test'] = 'test'
         return request_kwargs
 


### PR DESCRIPTION
Hey! Here's an unfortunately API-breaking change that provides `relative_url` to `before_request` so that overriding classes can do stuff with that.
