### PR TITLE
fix installation problem with pip versions 6.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python
 
-from pip.req import parse_requirements
-
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements('requirements.txt')
-
-# reqs is a list of requirement
-# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
-
-
 try:
     from setuptools import setup
 except ImportError:
@@ -34,7 +24,9 @@ setup(
     ],
     package_dir={'nap': 'nap'},
     include_package_data=True,
-    install_requires=reqs,
+    install_requires=[
+        'requests>=2.2.1,<3.0.0'
+    ],
     license='MIT',
     zip_safe=False,
     keywords='nap rest requests http',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ readme = """Read docs from GitHub_
 
 setup(
     name='nap',
-    version='2.0.0-dev',
+    version='2.0.1',
     description='Convenient way to request HTTP APIs',
     long_description=readme,
     author='Kimmo Brunfeldt',


### PR DESCRIPTION
The signature of `pip.req.parse_requirements()` has changed in version 6.0,
so nap cannot be installed with current pip versions.
I think it's ok to put the dependency on requests directly in setup.py
without using pip to avoid this ;)
