### PR TITLE
Fix URL joining with Python 3.7

### DIFF
--- a/nap/url.py
+++ b/nap/url.py
@@ -138,11 +138,17 @@ class Url(object):
 
     def _remove_leading_slash(self, text):
         return text[1:] if text.startswith('/') else text
+    
+    def _ensure_trailing_slash(self, text):
+        return text if text.endswith('/') else text + '/'
 
     def _new_url(self, relative_url):
         """Create new Url which points to new url."""
 
         return Url(
-            urljoin(self._base_url, relative_url),
+            urljoin(
+                self._ensure_trailing_slash(self._base_url),
+                self._remove_leading_slash(relative_url)
+            ),
             **self._default_kwargs
         )


### PR DESCRIPTION
Possibly something's changed with `urllib.parse`, but definitely the URL joining tests where the baseurl does _not_ end in a slash were failing on my Ubuntu 18.04 Python 3.7. That is to say, that version works like this:

```py
urljoin("http://example.com/api", "foo") == "http://example.com/foo"
urljoin("http://example.com/api", "/foo") == "http://example.com/foo"
urljoin("http://example.com/api/", "foo") == "http://example.com/foo"
urljoin("http://example.com/api/", "/foo") == "http://example.com/api/foo"
```

I think in terms of the nap API, the final case is the only one that is "right", so this change always ensures that is the way we work.

Fixes: #12, #14 