### PR TITLE
Drop end-of-life Python versions, add 3.6, 3.7, 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, style
+envlist = py27, py36, py37, py38, style
 
 [testenv]
 setenv =


### PR DESCRIPTION
Here are links to PEPs where the lifecycles of these Python versions are discussed

3.6 is still supported: https://www.python.org/dev/peps/pep-0494/#lifespan
2.6 is no longer supported: https://www.python.org/dev/peps/pep-0361/#release-lifespan
2.7 is still supported: https://www.python.org/dev/peps/pep-0373/#update
3.7 is still very much supported and 3.8 would be the leading edge.